### PR TITLE
Start first word of a note with a capital.

### DIFF
--- a/src/ch15-02-deref.md
+++ b/src/ch15-02-deref.md
@@ -14,7 +14,7 @@ smart pointers to work in ways similar to references. Then we’ll look at
 Rust’s *deref coercion* feature and how it lets us work with either references
 or smart pointers.
 
-> Note: there’s one big difference between the `MyBox<T>` type we’re about to
+> Note: There’s one big difference between the `MyBox<T>` type we’re about to
 > build and the real `Box<T>`: our version will not store its data on the heap.
 > We are focusing this example on `Deref`, so where the data is actually stored
 > is less important than the pointer-like behavior.


### PR DESCRIPTION
Hi there,

Love the book, great work! 🙂 

Regarding the fix: other notes have the first word in the sentence start with a capital, which was not the case here. The error was not in the rendered version under `nostarch` by the way. I was triggered by a misalignment of "NOTE" in the black square of the printed version -- but I'm not sure where this error comes from, it seems a part of the final rendering/typesetting.